### PR TITLE
Apogee Detection Logic

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -6,7 +6,7 @@
 #include <Wire.h>
 
 // this will be used in debugging the code by printing out the output
-//the final code to be uploaded set DEBUG =0 to disable all debug statements
+// the final code to be uploaded set DEBUG =0 to disable all debug statements
 
 #define DEBUG 1
 #if DEBUG == 1
@@ -19,41 +19,38 @@
 #define debugf(x, y)
 #endif
 
-//the sea level pressure of the area we are at
+// the sea level pressure of the area we are at
 #define SEA_LEVEL_PRESSURE 102400
 
 // Timing delays
 #define SETUP_DELAY 5000
 #define SHORT_DELAY 10
 
-
 #define BAUD_RATE 115200
 #define GPS_BAUD_RATE 9600
-
 
 #define SD_CS_PIN 5
 
 // Pin to start ejection charge
 #define EJECTION_PIN 4
 
-//buzzer signal pin
+// buzzer signal pin
 #define buzzer_pin 32
 
-//initializing the state machine states
+// initializing the state machine states
 #define PRE_FLIGHT_GROUND_STATE 0
 #define POWERED_FLIGHT_STATE 1
-#define BALLISTIC_DESCENT_STATE 2
-#define CHUTE_DESCENT_STATE 3
-#define POST_FLIGHT_GROUND_STATE 4
+#define CHUTE_DESCENT_STATE 2
+#define POST_FLIGHT_GROUND_STATE 3
 
-//define the thresholds of the various displacements that need to be achieved in the state machine
+// define the thresholds of the various displacements that need to be achieved in the state machine
 #define GROUND_STATE_DISPLACEMENT 10
-#define BELOW_APOGEE_LEVEL_DISPLACEMENT 10
+#define BELOW_APOGEE_LEVEL_DISPLACEMENT 1
 
 #define GPS_TX_PIN 17
 #define GPS_RX_PIN 16
 
-//defining the two CPU cores to be used
+// defining the two CPU cores to be used
 extern const BaseType_t pro_cpu;
 extern const BaseType_t app_cpu;
 
@@ -63,7 +60,7 @@ extern const BaseType_t app_cpu;
 
 // MQTT Broker IP address
 #define mqtt_server "192.168.100.54"
-//size of the data to be transmitted. can be increased or decreased based on the quantity of data you will transmit
+// size of the data to be transmitted. can be increased or decreased based on the quantity of data you will transmit
 #define MQTT_BUFFER_SIZE 300
 #define MQQT_PORT 1883
 
@@ -77,8 +74,8 @@ extern float MAX_ALTITUDE;
 // It includes rocket altitude, accelerations in the x, y and z directions
 // Gryroscope values in the x, y and z direcion
 // filtered altitude, velocity and acceleration
-// GPS longitude, laltitude, altitude and 
-//state and temperature
+// GPS longitude, laltitude, altitude and
+// state and temperature
 struct Data
 {
     uint64_t timeStamp;

--- a/src/checkstate.cpp
+++ b/src/checkstate.cpp
@@ -7,7 +7,7 @@ float MAX_ALTITUDE = 0;
 
 // This checks that we have started ascent
 // compares the current displacement to the set threshold of the ground state displacement
-//if found to be above, we have achieved lift off
+// if found to be above, we have achieved lift off
 int checkInPoweredFlight(float altitude)
 {
     float displacement = altitude - BASE_ALTITUDE;
@@ -23,40 +23,24 @@ int checkInPoweredFlight(float altitude)
 
 // This checks that we have reached apogee
 // At apogee velocity is zero so we check for velocity less than or equal to zero
-// we also check if the current altitude is less than the previous altitude 
-//this would determine that the rocket has began descent
-int checkForApogee(float velocity, float currentAltitude, float previousAltitude)
+// we also check if the current altitude is less than the previous altitude
+// this would determine that the rocket has began descent
+int checkForApogee(float velocity, float currentAltitude, float temporalMaxAltitude)
 {
-    if ((previousAltitude - currentAltitude) > 5)
+    if ((temporalMaxAltitude - currentAltitude) > 5)
     {
 
-        MAX_ALTITUDE = currentAltitude;
-        return BALLISTIC_DESCENT_STATE;
+        ejection();
+        return CHUTE_DESCENT_STATE;
     }
     else if (velocity <= 0)
     {
-        MAX_ALTITUDE = currentAltitude;
-        return BALLISTIC_DESCENT_STATE;
-    }
-    else
-    {
-        return POWERED_FLIGHT_STATE;
-    }
-}
-
-// Deploys parachute if we moved down below the set threshold for below apogee displacement
-int deployChute(float altitude)
-{
-    float displacement = MAX_ALTITUDE - altitude;
-    if (displacement > BELOW_APOGEE_LEVEL_DISPLACEMENT)
-    {
-        // the ejection function is called which fires the ejection charge
         ejection();
         return CHUTE_DESCENT_STATE;
     }
     else
     {
-        return BALLISTIC_DESCENT_STATE;
+        return POWERED_FLIGHT_STATE;
     }
 }
 
@@ -81,16 +65,14 @@ int checkGround(float altitude)
 // We check if we have reached apogee to move to BALLISTIC_DESCENT_STATE
 // We deploy parachute to move to CHUTE_DESCENT_STATE
 // We check if we have reached the ground to move to POST_FLIGHT_GROUND_STATE
-int checkState(float currentAltitude, float previousAltitude, float velocity, float acceleration, int state)
+int checkState(float currentAltitude, float temporalMaxAltitude, float velocity, float acceleration, int state)
 {
     switch (state)
     {
     case PRE_FLIGHT_GROUND_STATE:
         return checkInPoweredFlight(currentAltitude);
     case POWERED_FLIGHT_STATE:
-        return checkForApogee(velocity, currentAltitude, previousAltitude);
-    case BALLISTIC_DESCENT_STATE:
-        return deployChute(currentAltitude);
+        return checkForApogee(velocity, currentAltitude, temporalMaxAltitude);
     case CHUTE_DESCENT_STATE:
         return checkGround(currentAltitude);
     case POST_FLIGHT_GROUND_STATE:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int access_point = 0;
 
 float BASE_ALTITUDE = 0;
 
-float previousAltitude;
+float temporalMaxAltitude = 0;
 
 volatile int state = 0;
 
@@ -75,9 +75,13 @@ struct Data readData()
 
   // using mutex to modify state
   portENTER_CRITICAL(&mutex);
-  state = checkState(filtered_values.displacement, previousAltitude, filtered_values.velocity, filtered_values.acceleration, state);
+  state = checkState(filtered_values.displacement, temporalMaxAltitude, filtered_values.velocity, filtered_values.acceleration, state);
   portEXIT_CRITICAL(&mutex);
-  previousAltitude = filtered_values.displacement;
+  if (temporalMaxAltitude < filtered_values.displacement)
+  {
+    temporalMaxAltitude = filtered_values.displacement;
+  }
+
   ld = formart_data(readings, filtered_values);
   ld.state = state;
   ld.timeStamp = millis();


### PR DESCRIPTION
Fix apogee detection logic to implement the use of temporal maximum altitude.
The logic is that we initialize the temporal maximum altitude to 0. Then we compare the temporal maximum altitude value to the Kalman filter's filtered displacement value. If the filtered value is greater, then `temporalMaxAltitude=filtered_values.displacement`