### PR TITLE
update x_hat to use BASE_ALTITUDE

### DIFF
--- a/src/kalmanfilter.cpp
+++ b/src/kalmanfilter.cpp
@@ -38,7 +38,7 @@ BLA::Matrix<3, 3> I = {1, 0, 0,
                        0, 1, 0,
                        0, 0, 1};
 
-BLA::Matrix<3, 1> x_hat = {1500.0,
+BLA::Matrix<3, 1> x_hat = {BASE_ALTITUDE,
                            0.0,
                            0.0};
 


### PR DESCRIPTION
FIX X_hat to use the base altitude value that is determined during initial booting which will resonate with the altitude of the rocket at the base station